### PR TITLE
Fix memory leak when switching ISO files

### DIFF
--- a/Pokemon-XD-Common/Utility/BaseExtractedFile.cs
+++ b/Pokemon-XD-Common/Utility/BaseExtractedFile.cs
@@ -22,6 +22,8 @@ namespace XDCommon.Utility
             if (!disposedValue)
             {
                 ExtractedFile.Dispose();
+                ExtractedFile = null;
+
                 disposedValue = true;
             }
         }

--- a/Pokemon-XD-Tool/MainForm.cs
+++ b/Pokemon-XD-Tool/MainForm.cs
@@ -162,6 +162,13 @@ namespace Randomizer
             // did they give us crap?
             try
             {
+                isoExtractor?.Dispose();
+                iso?.Dispose();
+                gameExtractor = null;
+                isoExtractor = null;
+                iso = null;
+                gamePictureBox.Image = null;
+
                 if (openISODialog.FileName.EndsWith("zip"))
                 {
                     if (!Configuration.UseMemoryStreams)


### PR DESCRIPTION
Randomizing then switching ISOs repeatedly caused the form to never release the old ISOs memory. Explicitly disposing them fixes this.