### PR TITLE
Fix starter randomization in Colosseum

### DIFF
--- a/Pokemon-XD-Tool/Randomizer.csproj
+++ b/Pokemon-XD-Tool/Randomizer.csproj
@@ -8,9 +8,9 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Authors>rotobash</Authors>
     <PackageProjectUrl>https://github.com/rotobash/pokemon-ngc-rando</PackageProjectUrl>
-    <AssemblyVersion>1.1.3.0</AssemblyVersion>
-    <FileVersion>1.1.3.0</FileVersion>
-    <Version>1.1.3</Version>
+    <AssemblyVersion>1.1.4.0</AssemblyVersion>
+    <FileVersion>1.1.4.0</FileVersion>
+    <Version>1.1.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Pokemon-XD-Tool/Shufflers/BingoCardShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/BingoCardShuffler.cs
@@ -43,23 +43,27 @@ namespace Randomizer.Shufflers
                     {
                         // randomize starter
                         battleBingoPokemon = card.StartingPokemon;
-                        Logger.Log($"Starter: {extractedGame.PokemonList[battleBingoPokemon.Pokemon].Name} -> ");
                     }
                     else
                     {
                         var panel = card.Panels[i];
                         if (panel.PanelType != BattleBingoPanelType.Pokemon) continue;
                         battleBingoPokemon = panel.BingoPokemon;
-                        Logger.Log($"Panel Pokemon: {extractedGame.PokemonList[battleBingoPokemon.Pokemon].Name} -> ");
                     }
 
                     newPoke = extractedGame.PokemonList[battleBingoPokemon.Pokemon];
                     if (settings.RandomizeBattleBingoPokemon)
                     {
+                        if (i == card.Panels.Length)
+                            Logger.Log("Starter: ");
+                        else
+                            Logger.Log("Panel Pokemon:");
+
+                        Logger.Log($"{extractedGame.PokemonList[battleBingoPokemon.Pokemon].Name}");
                         newPoke = potentialPokes[random.Next(0, potentialPokes.Length)];
                         battleBingoPokemon.Pokemon = (ushort)newPoke.Index;
+                        Logger.Log($" -> {extractedGame.PokemonList[battleBingoPokemon.Pokemon].Name}\n");
                     }
-                    Logger.Log($"{extractedGame.PokemonList[battleBingoPokemon.Pokemon].Name}\n");
 
                     if (settings.RandomizeBattleBingoMoveSets)
                     {
@@ -74,8 +78,8 @@ namespace Randomizer.Shufflers
                         }
                         // pick good moves
                         battleBingoPokemon.Move = (ushort)movePool.ElementAt(random.Next(0, movePool.Count())).MoveIndex;
+                        Logger.Log($"Move: {extractedGame.MoveList[battleBingoPokemon.Move].Name}\n\n");
                     }
-                    Logger.Log($"Move: {extractedGame.MoveList[battleBingoPokemon.Move].Name}\n\n");
                 }
                 // if you shuffle the panels do you have to write back the offset?
             }

--- a/Pokemon-XD-Tool/Shufflers/MoveShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/MoveShuffler.cs
@@ -29,14 +29,14 @@ namespace Randomizer.Shufflers
             foreach (var move in extractedGame.ValidMoves)
             {
 
-                Logger.Log($"{move.Name}: \n");
+                Logger.Log($"{move.Name}\n");
                 if (settings.RandomMovePower && move.BasePower > 0)
                 {
                     // sample move power with the power of math!!
                     // basically moves will average at 80 power but can be from 10 to 150
                     move.BasePower = (byte)random.Sample(80, 70);
+                    Logger.Log($"Power: {move.BasePower}\n");
                 }
-                Logger.Log($"Power: {move.BasePower}\n");
 
                 if (settings.RandomMoveAcc && move.Accuracy > 0)
                 {
@@ -47,15 +47,15 @@ namespace Randomizer.Shufflers
                         acc = (byte)Math.Min(100, random.Sample(80, 30));
                     } while (acc == 100 && move.EffectType == MoveEffectTypes.OHKO);
                     move.Accuracy = acc;
+                    Logger.Log($"Accuracy: {move.Accuracy}\n");
                 }
-                Logger.Log($"Accuracy: {move.Accuracy}\n");
 
                 if (settings.RandomMovePP)
                 {
                     // pick from 1, 8, multiply by 5 to get the 5 - 40 range for PP
                     move.PP = (byte)Math.Max(5, Math.Round(random.Sample(4, 4)) * 5);
+                    Logger.Log($"PP: {move.PP}\n");
                 }
-                Logger.Log($"PP: {move.PP}\n");
 
                 if (settings.RandomMoveTypes && move.Type != PokemonTypes.None)
                 {
@@ -68,16 +68,16 @@ namespace Randomizer.Shufflers
                     }
                     while (newType == PokemonTypes.None);
                     move.Type = newType;
+                    Logger.Log($"Type: {move.Type}\n");
                 }
-                Logger.Log($"Type: {move.Type}\n");
 
                 // I don't know if this will work for colo, probably not
                 if (settings.RandomMoveCategory && move.Category != MoveCategories.None)
                 {
                     var newCategory = (MoveCategories)random.Next(1, 3);
                     move.Category = newCategory;
+                    Logger.Log($"Category: {move.Category}\n\n");
                 }
-                Logger.Log($"Category: {move.Category}\n\n");
             }
         }
 

--- a/Pokemon-XD-Tool/Shufflers/PokeSpotShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/PokeSpotShuffler.cs
@@ -31,10 +31,10 @@ namespace Randomizer.Shufflers
             {
                 Logger.Log($"PokeSpot Type: {pokeSpotPoke.PokeSpot.PokeSpotType}\n\n");
                 var pokemon = extractedGame.PokemonList[pokeSpotPoke.Pokemon];
-                if (pokeSpotPoke.Pokemon == RandomizerConstants.BonslyIndex)
+                if (pokeSpotPoke.Pokemon == RandomizerConstants.BonslyIndex && settings.EasyBonsly)
                 {
                     // I don't know if this'll work or not...
-                    pokeSpotPoke.EncounterPercentage = settings.EasyBonsly ? (byte)100 : pokeSpotPoke.EncounterPercentage;
+                    pokeSpotPoke.EncounterPercentage = 100;
                     Logger.Log("Bonsly damnit stop running away!\n");
                     continue;
                 }

--- a/Pokemon-XD-Tool/Shufflers/PokemonTraitShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/PokemonTraitShuffler.cs
@@ -105,7 +105,7 @@ namespace Randomizer.Shufflers
                 if (RandomizerConstants.SpecialPokemon.Contains(poke.Index))
                     continue;
 
-                Logger.Log($"{poke.Name}'s Traits:\n\n");
+                Logger.Log($"{poke.Name}\n");
 
                 ChangeCompatibility(random, settings.TMCompatibility, poke, extractedGame, true);
                 if (extractedGame.TutorMoves.Length > 0)

--- a/Pokemon-XD-Tool/Shufflers/StaticPokemonShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/StaticPokemonShuffler.cs
@@ -173,7 +173,7 @@ namespace Randomizer.Shufflers
                     {
                         var newStarter = extractedGame.ValidPokemon[random.Next(0, extractedGame.ValidPokemon.Length)];
                         index = newStarter.Index;
-                        secondStage = extractedGame.PokemonList[index].Evolutions[0];
+                        secondStage = newStarter.Evolutions[0];
                         condition = !PokemonTraitShuffler.CheckForSplitOrEndEvolution(newStarter, out int _)
                             && PokemonTraitShuffler.CheckForSplitOrEndEvolution(extractedGame.PokemonList[secondStage.EvolvesInto], out int count)
                             && count == 0

--- a/Pokemon-XD-Tool/Shufflers/StaticPokemonShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/StaticPokemonShuffler.cs
@@ -17,6 +17,7 @@ namespace Randomizer.Shufflers
             List<Pokemon> newRequestedPokemon = new List<Pokemon>();
             List<Pokemon> newGivenPokemon = new List<Pokemon>();
             var pokemon = extractedGame.ValidPokemon;
+            Logger.Log("=============================== Trades ===============================\n\n");
             // set given
             switch (settings.Trade)
             {
@@ -70,10 +71,14 @@ namespace Randomizer.Shufflers
 
         public static void RandomizeColoStatics(AbstractRNG random, StaticPokemonShufflerSettings settings, IGiftPokemon[] starters, ExtractedGame extractedGame)
         {
-            RandomizeStarters(random, settings, extractedGame, starters);
+            if (starters.Length != 2)
+                return;
+
+            RandomizeStarters(random, settings, extractedGame, starters[0], starters[1]);
 
             List<Pokemon> newGivenPokemon = new List<Pokemon>();
             var pokemon = extractedGame.ValidPokemon;
+            Logger.Log("=============================== Trades ===============================\n\n");
             // set given
             switch (settings.Trade)
             {
@@ -101,119 +106,130 @@ namespace Randomizer.Shufflers
             Logger.Log($"Given Pokemon: {string.Join(", ", newGivenPokemon.Select(p => p.Name))}\n");
         }
 
-        private static void RandomizeStarters(AbstractRNG random, StaticPokemonShufflerSettings settings, ExtractedGame extractedGame, params IGiftPokemon[] starters)
+        private static void RandomizeStarters(AbstractRNG random, StaticPokemonShufflerSettings settings, ExtractedGame extractedGame, IGiftPokemon starter1, IGiftPokemon starter2 = null)
         {
+            Logger.Log("=============================== Starters ===============================\n\n");
+
+            if (settings.Starter == StarterRandomSetting.Custom)
+            {
+                starter1.Pokemon = (ushort?)extractedGame.PokemonList.FirstOrDefault(p => p.Name.ToLower() == settings.Starter1.ToLower())?.Index ?? starter1.Pokemon;
+                if (starter2 != null)
+                    starter2.Pokemon = (ushort?)extractedGame.PokemonList.FirstOrDefault(p => p.Name.ToLower() == settings.Starter2.ToLower())?.Index ?? starter2.Pokemon;
+            }
+            else
+            {
+                RandomizeStarter(random, settings, extractedGame, starter1);
+                RandomizeStarter(random, settings, extractedGame, starter2);
+            }
+
+            Logger.Log($"Your new starter is {extractedGame.PokemonList[starter1.Pokemon].Name}\n");
+            UpdateStarterMoveset(random, settings, extractedGame, starter1);
+
+            if (starter2 != null)
+            {
+                Logger.Log($"Your new starter is {extractedGame.PokemonList[starter2.Pokemon].Name}\n");
+                UpdateStarterMoveset(random, settings, extractedGame, starter2);
+            }
+
+        }
+
+        private static void RandomizeStarter(AbstractRNG random, StaticPokemonShufflerSettings settings, ExtractedGame extractedGame, IGiftPokemon starter)
+        {
+            if (starter == null)
+                return;
+
             int index = 0;
             Evolution secondStage;
             bool condition = false;
-
-            if (starters.Length < 1 && starters.Length > 2)
-                return;
-
-            Logger.Log("=============================== Statics ===============================\n\n");
-            // pick starters
-            // basically set a condition based on the setting, keep looping till you meet it
-            for (int i = 0; i < starters.Length; i++)
+            switch (settings.Starter)
             {
-                var starter = starters[i];
-
-                switch (settings.Starter)
+                case StarterRandomSetting.Random:
                 {
-                    case StarterRandomSetting.Custom:
-                        {
-                            var starterName = i == 0 ? settings.Starter1.ToLower() : settings.Starter2.ToLower();
-                            index = extractedGame.PokemonList.FirstOrDefault(p => p.Name.ToLower() == starterName)?.Index ?? starter.Pokemon;
-                        }
-                        break;
-                    case StarterRandomSetting.Random:
-                        {
-                            while (index == 0 || RandomizerConstants.SpecialPokemon.Contains(index))
-                            {
-                                index = random.Next(1, extractedGame.PokemonList.Length);
-                            }
-                        }
-                        break;
-                    case StarterRandomSetting.RandomThreeStage:
-                        while (!condition)
-                        {
-                            var newStarter = extractedGame.PokemonList[random.Next(0, extractedGame.ValidPokemon.Length)];
-                            index = newStarter.Index;
-                            secondStage = extractedGame.PokemonList[index].Evolutions[0];
-                            condition = !PokemonTraitShuffler.CheckForSplitOrEndEvolution(newStarter, out int _)
-                                && !PokemonTraitShuffler.CheckForSplitOrEndEvolution(extractedGame.PokemonList[secondStage.EvolvesInto], out int _)
-                                // check if any pokemon evolve into this one, less likely for three stages but probably good to check anyway
-                                && !extractedGame.ValidPokemon.Any(p =>
-                                {
-                                    for (int i = 0; i < p.Evolutions.Length; i++)
-                                    {
-                                        if (p.Evolutions[i].EvolvesInto == index)
-                                            return true;
-                                    }
-                                    return false;
-                                });
-                        }
-                        break;
-                    case StarterRandomSetting.RandomTwoStage:
-                        while (!condition)
-                        {
-                            var newStarter = extractedGame.PokemonList[random.Next(0, extractedGame.ValidPokemon.Length)];
-                            index = newStarter.Index;
-                            secondStage = extractedGame.PokemonList[index].Evolutions[0];
-                            condition = !PokemonTraitShuffler.CheckForSplitOrEndEvolution(newStarter, out int _)
-                                && PokemonTraitShuffler.CheckForSplitOrEndEvolution(extractedGame.PokemonList[secondStage.EvolvesInto], out int count)
-                                && count == 0
-                                // check if any pokemon evolve into this one
-                                && !extractedGame.ValidPokemon.Any(p =>
-                                {
-                                    for (int i = 0; i < p.Evolutions.Length; i++)
-                                    {
-                                        if (p.Evolutions[i].EvolvesInto == index)
-                                            return true;
-                                    }
-                                    return false;
-                                });
-                        }
-                        break;
-                    case StarterRandomSetting.RandomSingleStage:
-                        while (!condition)
-                        {
-                            var newStarter = extractedGame.PokemonList[random.Next(0, extractedGame.ValidPokemon.Length)];
-                            index = newStarter.Index;
-                            condition = PokemonTraitShuffler.CheckForSplitOrEndEvolution(newStarter, out int count)
-                                && count == 0
-                                // check if any pokemon evolve into this one
-                                && !extractedGame.ValidPokemon.Any(p =>
-                                {
-                                    for (int i = 0; i < p.Evolutions.Length; i++)
-                                    {
-                                        if (p.Evolutions[i].EvolvesInto == index)
-                                            return true;
-                                    }
-                                    return false;
-                                });
-                        }
-                        break;
-                    default:
-                    case StarterRandomSetting.Unchanged:
-                        index = starter.Pokemon;
-                        break;
+                    index = extractedGame.ValidPokemon[random.Next(0, extractedGame.ValidPokemon.Length)].Index;
                 }
-                starter.Pokemon = (ushort)index;
-                Logger.Log($"Your new starter is {extractedGame.PokemonList[index].Name}\n");
-
-                // instance pokemon have separate movesets than the pool
-                // i.e. if you don't update the moveset than your starter will have Eevee's move set
-                ushort[] moves;
-                if (settings.MoveSetOptions.RandomizeMovesets || settings.Starter != StarterRandomSetting.Unchanged)
-                {
-                    Logger.Log($"It knows:\n");
-                    moves = MoveShuffler.GetNewMoveset(random, settings.MoveSetOptions, starter.Pokemon, starter.Level, extractedGame);
-                    for (int j = 0; j < moves.Length; j++)
+                break;
+                case StarterRandomSetting.RandomThreeStage:
+                    while (!condition)
                     {
-                        var move = moves[j];
-                        Logger.Log($"{extractedGame.MoveList[move].Name}\n");
-                        starter.SetMove(j, move);
+                        var newStarter = extractedGame.ValidPokemon[random.Next(0, extractedGame.ValidPokemon.Length)];
+                        index = newStarter.Index;
+                        secondStage = newStarter.Evolutions[0];
+                        condition = !PokemonTraitShuffler.CheckForSplitOrEndEvolution(newStarter, out int _)
+                            && !PokemonTraitShuffler.CheckForSplitOrEndEvolution(extractedGame.PokemonList[secondStage.EvolvesInto], out int _)
+                            // check if any pokemon evolve into this one, less likely for three stages but probably good to check anyway
+                            && !extractedGame.ValidPokemon.Any(p =>
+                            {
+                                for (int i = 0; i < p.Evolutions.Length; i++)
+                                {
+                                    if (p.Evolutions[i].EvolvesInto == index)
+                                        return true;
+                                }
+                                return false;
+                            });
                     }
+                    break;
+                case StarterRandomSetting.RandomTwoStage:
+                    while (!condition)
+                    {
+                        var newStarter = extractedGame.ValidPokemon[random.Next(0, extractedGame.ValidPokemon.Length)];
+                        index = newStarter.Index;
+                        secondStage = extractedGame.PokemonList[index].Evolutions[0];
+                        condition = !PokemonTraitShuffler.CheckForSplitOrEndEvolution(newStarter, out int _)
+                            && PokemonTraitShuffler.CheckForSplitOrEndEvolution(extractedGame.PokemonList[secondStage.EvolvesInto], out int count)
+                            && count == 0
+                            // check if any pokemon evolve into this one
+                            && !extractedGame.ValidPokemon.Any(p =>
+                            {
+                                for (int i = 0; i < p.Evolutions.Length; i++)
+                                {
+                                    if (p.Evolutions[i].EvolvesInto == index)
+                                        return true;
+                                }
+                                return false;
+                            });
+                    }
+                    break;
+                case StarterRandomSetting.RandomSingleStage:
+                    while (!condition)
+                    {
+                        var newStarter = extractedGame.ValidPokemon[random.Next(0, extractedGame.ValidPokemon.Length)];
+                        index = newStarter.Index;
+                        condition = PokemonTraitShuffler.CheckForSplitOrEndEvolution(newStarter, out int count)
+                            && count == 0
+                            // check if any pokemon evolve into this one
+                            && !extractedGame.ValidPokemon.Any(p =>
+                            {
+                                for (int i = 0; i < p.Evolutions.Length; i++)
+                                {
+                                    if (p.Evolutions[i].EvolvesInto == index)
+                                        return true;
+                                }
+                                return false;
+                            });
+                    }
+                    break;
+                default:
+                case StarterRandomSetting.Unchanged:
+                    index = starter.Pokemon;
+                    break;
+            }
+            starter.Pokemon = (ushort)index;
+        }
+
+        private static void UpdateStarterMoveset(AbstractRNG random, StaticPokemonShufflerSettings settings, ExtractedGame extractedGame, IGiftPokemon starter)
+        {
+            // instance pokemon have separate movesets than the pool
+            // i.e. if you don't update the moveset than your starter will have Eevee's move set
+            ushort[] moves;
+            if (settings.MoveSetOptions.RandomizeMovesets || settings.Starter != StarterRandomSetting.Unchanged)
+            {
+                Logger.Log($"It knows:\n");
+                moves = MoveShuffler.GetNewMoveset(random, settings.MoveSetOptions, starter.Pokemon, starter.Level, extractedGame);
+                for (int j = 0; j < moves.Length; j++)
+                {
+                    var move = moves[j];
+                    Logger.Log($"{extractedGame.MoveList[move].Name}\n");
+                    starter.SetMove(j, move);
                 }
             }
         }

--- a/Pokemon-XD-Tool/Shufflers/TeamShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/TeamShuffler.cs
@@ -37,7 +37,7 @@ namespace Randomizer.Shufflers
                         if (pokemon.Pokemon == 0)
                             continue;
 
-                        RandomizePokemon(random, settings, pokemon, extractedGame.PokemonList);
+                        RandomizePokemon(random, settings, extractedGame, pokemon);
                         Logger.Log($"{extractedGame.PokemonList[pokemon.Pokemon].Name}\n");
                         Logger.Log($"Is a shadow Pokemon: {pokemon.IsShadow}\n");
 
@@ -77,21 +77,21 @@ namespace Randomizer.Shufflers
             }
         }
 
-        public static void RandomizePokemon(AbstractRNG random, TeamShufflerSettings settings, ITrainerPokemon pokemon, Pokemon[] pokemonList)
+        public static void RandomizePokemon(AbstractRNG random, TeamShufflerSettings settings, ExtractedGame extractedGame, ITrainerPokemon pokemon)
         {
             if (settings.RandomizePokemon)
             {
                 var index = 0;
-                while (index == 0 || RandomizerConstants.SpecialPokemon.Contains(index) || (settings.DontUseLegendaries && RandomizerConstants.Legendaries.Contains(index)))
+                while (index == 0 || (settings.DontUseLegendaries && RandomizerConstants.Legendaries.Contains(index)))
                 {
-                    index = random.Next(1, pokemonList.Length);
+                    index = extractedGame.ValidPokemon[random.Next(0, extractedGame.ValidPokemon.Length)].Index;
                 }
                 pokemon.Pokemon = (ushort)index;
             }
 
             if (settings.ForceFullyEvolved && pokemon.Level >= settings.ForceFullyEvolvedLevel)
             {
-                var currPoke = pokemonList[pokemon.Pokemon];
+                var currPoke = extractedGame.PokemonList[pokemon.Pokemon];
                 if (PokemonTraitShuffler.CheckForSplitOrEndEvolution(currPoke, out var count) && count > 0)
                 {
                     // randomly pick from the split

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 
-if [[ -z $1 ]]
-then
-  OUT='.'
-else
-  OUT="$1"
-fi
+mkdir -p "ngc-randomizer"
+mkdir -p "ngc-randomizer-sc"
 
-echo $OUT
-
-mkdir -p "$OUT/ngc-randomizer"
-mkdir -p "$OUT/ngc-randomizer-sc"
-
-dotnet publish --configuration 'Release' --self-contained true --runtime win-x64 -o "$1/ngc-randomizer-sc"
-dotnet publish --configuration 'Release' --self-contained false -o "$1/ngc-randomizer"
+dotnet publish --configuration 'Release' --self-contained true --runtime win-x64 -o "ngc-randomizer-sc"
+dotnet publish --configuration 'Release' --self-contained false -o "ngc-randomizer"

--- a/build.sh
+++ b/build.sh
@@ -2,15 +2,15 @@
 
 if [[ -z $1 ]]
 then
-  PATH='.'
+  OUT='.'
 else
-  PATH="$1"
+  OUT="$1"
 fi
 
-echo $PATH
+echo $OUT
 
-mkdir -p "$PATH/ngc-randomizer"
-mkdir -p "$PATH/ngc-randomizer-sc"
+mkdir -p "$OUT/ngc-randomizer"
+mkdir -p "$OUT/ngc-randomizer-sc"
 
 dotnet publish --configuration 'Release' --self-contained true --runtime win-x64 -o "$1/ngc-randomizer-sc"
 dotnet publish --configuration 'Release' --self-contained false -o "$1/ngc-randomizer"


### PR DESCRIPTION
Fixes #14 
Fixes some unsafety when picking single/two/three stage evolutions for starters

Also, this reduces logging output if nothing has changed.