### PR TITLE
Fix evolutions by BST from looping

### DIFF
--- a/Pokemon-XD-Common/Configuration.cs
+++ b/Pokemon-XD-Common/Configuration.cs
@@ -143,7 +143,7 @@ namespace XDCommon
             }
             set
             {
-                AddOrUpdateAppSettings(nameof(PokemonEasierFinalEvolutionLevel), value.ToString());
+                AddOrUpdateAppSettings(nameof(PokemonEasierSecondEvolutionLevel), value.ToString());
             }
         }
 

--- a/Pokemon-XD-Tool/OptionsForm.Designer.cs
+++ b/Pokemon-XD-Tool/OptionsForm.Designer.cs
@@ -36,13 +36,7 @@ namespace Randomizer
             this.extractDirLabel = new System.Windows.Forms.Label();
             this.browseForDirButton = new System.Windows.Forms.Button();
             this.label7 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.pokemonBSTSelector = new System.Windows.Forms.NumericUpDown();
-            this.movePower = new System.Windows.Forms.NumericUpDown();
-            this.label6 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.fileStreamCheck = new System.Windows.Forms.CheckBox();
-            this.label4 = new System.Windows.Forms.Label();
             this.label8 = new System.Windows.Forms.Label();
             this.bstRangeSelector = new System.Windows.Forms.NumericUpDown();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
@@ -50,6 +44,12 @@ namespace Randomizer
             this.pokemonSecondEvolutionLevelSelector = new System.Windows.Forms.NumericUpDown();
             this.label9 = new System.Windows.Forms.Label();
             this.label10 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.fileStreamCheck = new System.Windows.Forms.CheckBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.movePower = new System.Windows.Forms.NumericUpDown();
+            this.pokemonBSTSelector = new System.Windows.Forms.NumericUpDown();
+            this.label3 = new System.Windows.Forms.Label();
             this.label11 = new System.Windows.Forms.Label();
             this.pokemonImpossibleEvolutionLevelSelector = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
@@ -57,12 +57,12 @@ namespace Randomizer
             this.infoToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pokemonBSTSelector)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.movePower)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bstRangeSelector)).BeginInit();
             this.tableLayoutPanel3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pokemonFinalEvolutionLevelSelector)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pokemonSecondEvolutionLevelSelector)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.movePower)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pokemonBSTSelector)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pokemonImpossibleEvolutionLevelSelector)).BeginInit();
             this.SuspendLayout();
             // 
@@ -151,67 +151,6 @@ namespace Randomizer
             this.label7.Text = "Easier Evolution Level:";
             this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(18, 155);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(93, 30);
-            this.label3.TabIndex = 1;
-            this.label3.Text = "Good Pokemon BST:";
-            // 
-            // pokemonBSTSelector
-            // 
-            this.pokemonBSTSelector.Location = new System.Drawing.Point(129, 158);
-            this.pokemonBSTSelector.Maximum = new decimal(new int[] {
-            680,
-            0,
-            0,
-            0});
-            this.pokemonBSTSelector.Minimum = new decimal(new int[] {
-            180,
-            0,
-            0,
-            0});
-            this.pokemonBSTSelector.Name = "pokemonBSTSelector";
-            this.pokemonBSTSelector.Size = new System.Drawing.Size(169, 23);
-            this.pokemonBSTSelector.TabIndex = 5;
-            this.infoToolTip.SetToolTip(this.pokemonBSTSelector, "Minimum base stat total for a move to be considered \"good\".");
-            this.pokemonBSTSelector.Value = new decimal(new int[] {
-            180,
-            0,
-            0,
-            0});
-            this.pokemonBSTSelector.ValueChanged += new System.EventHandler(this.pokemonBSTSelector_ValueChanged);
-            // 
-            // movePower
-            // 
-            this.movePower.Location = new System.Drawing.Point(129, 119);
-            this.movePower.Minimum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.movePower.Name = "movePower";
-            this.movePower.Size = new System.Drawing.Size(169, 23);
-            this.movePower.TabIndex = 10;
-            this.infoToolTip.SetToolTip(this.movePower, "Minimum base power for a move to be considered \"good\".");
-            this.movePower.Value = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.movePower.ValueChanged += new System.EventHandler(this.movePower_ValueChanged);
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(18, 116);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(91, 30);
-            this.label6.TabIndex = 9;
-            this.label6.Text = "Good Damging Move Power:";
-            // 
             // label2
             // 
             this.label2.AutoSize = true;
@@ -220,27 +159,6 @@ namespace Randomizer
             this.label2.Size = new System.Drawing.Size(97, 15);
             this.label2.TabIndex = 0;
             this.label2.Text = "Extract Directory:";
-            // 
-            // fileStreamCheck
-            // 
-            this.fileStreamCheck.AutoSize = true;
-            this.fileStreamCheck.Location = new System.Drawing.Point(129, 18);
-            this.fileStreamCheck.Name = "fileStreamCheck";
-            this.fileStreamCheck.Size = new System.Drawing.Size(42, 19);
-            this.fileStreamCheck.TabIndex = 7;
-            this.fileStreamCheck.Text = "On";
-            this.infoToolTip.SetToolTip(this.fileStreamCheck, resources.GetString("fileStreamCheck.ToolTip"));
-            this.fileStreamCheck.UseVisualStyleBackColor = true;
-            this.fileStreamCheck.CheckedChanged += new System.EventHandler(this.memoryStreamCheck_CheckedChanged);
-            // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(18, 15);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(92, 15);
-            this.label4.TabIndex = 2;
-            this.label4.Text = "Use File Streams";
             // 
             // label8
             // 
@@ -352,6 +270,88 @@ namespace Randomizer
             this.label10.TabIndex = 15;
             this.label10.Text = "Second Stage";
             // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(18, 15);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(92, 15);
+            this.label4.TabIndex = 2;
+            this.label4.Text = "Use File Streams";
+            // 
+            // fileStreamCheck
+            // 
+            this.fileStreamCheck.AutoSize = true;
+            this.fileStreamCheck.Location = new System.Drawing.Point(129, 18);
+            this.fileStreamCheck.Name = "fileStreamCheck";
+            this.fileStreamCheck.Size = new System.Drawing.Size(42, 19);
+            this.fileStreamCheck.TabIndex = 7;
+            this.fileStreamCheck.Text = "On";
+            this.infoToolTip.SetToolTip(this.fileStreamCheck, resources.GetString("fileStreamCheck.ToolTip"));
+            this.fileStreamCheck.UseVisualStyleBackColor = true;
+            this.fileStreamCheck.CheckedChanged += new System.EventHandler(this.memoryStreamCheck_CheckedChanged);
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(18, 116);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(91, 30);
+            this.label6.TabIndex = 9;
+            this.label6.Text = "Good Damging Move Power:";
+            // 
+            // movePower
+            // 
+            this.movePower.Location = new System.Drawing.Point(129, 119);
+            this.movePower.Minimum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.movePower.Name = "movePower";
+            this.movePower.Size = new System.Drawing.Size(169, 23);
+            this.movePower.TabIndex = 10;
+            this.infoToolTip.SetToolTip(this.movePower, "Minimum base power for a move to be considered \"good\".");
+            this.movePower.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.movePower.ValueChanged += new System.EventHandler(this.movePower_ValueChanged);
+            // 
+            // pokemonBSTSelector
+            // 
+            this.pokemonBSTSelector.Location = new System.Drawing.Point(129, 158);
+            this.pokemonBSTSelector.Maximum = new decimal(new int[] {
+            680,
+            0,
+            0,
+            0});
+            this.pokemonBSTSelector.Minimum = new decimal(new int[] {
+            180,
+            0,
+            0,
+            0});
+            this.pokemonBSTSelector.Name = "pokemonBSTSelector";
+            this.pokemonBSTSelector.Size = new System.Drawing.Size(169, 23);
+            this.pokemonBSTSelector.TabIndex = 5;
+            this.infoToolTip.SetToolTip(this.pokemonBSTSelector, "Minimum base stat total for a move to be considered \"good\".");
+            this.pokemonBSTSelector.Value = new decimal(new int[] {
+            180,
+            0,
+            0,
+            0});
+            this.pokemonBSTSelector.ValueChanged += new System.EventHandler(this.pokemonBSTSelector_ValueChanged);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(18, 155);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(93, 30);
+            this.label3.TabIndex = 1;
+            this.label3.Text = "Good Pokemon BST:";
+            // 
             // label11
             // 
             this.label11.AutoSize = true;
@@ -378,6 +378,7 @@ namespace Randomizer
             0,
             0,
             0});
+            this.pokemonImpossibleEvolutionLevelSelector.ValueChanged += new System.EventHandler(this.pokemonImpossibleEvolutionLevelSelector_ValueChanged);
             // 
             // label1
             // 
@@ -400,13 +401,13 @@ namespace Randomizer
             this.tableLayoutPanel1.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pokemonBSTSelector)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.movePower)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bstRangeSelector)).EndInit();
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pokemonFinalEvolutionLevelSelector)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pokemonSecondEvolutionLevelSelector)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.movePower)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pokemonBSTSelector)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pokemonImpossibleEvolutionLevelSelector)).EndInit();
             this.ResumeLayout(false);
 

--- a/Pokemon-XD-Tool/OptionsForm.cs
+++ b/Pokemon-XD-Tool/OptionsForm.cs
@@ -25,6 +25,7 @@ namespace Randomizer
             pokemonImpossibleEvolutionLevelSelector.Value = Configuration.PokemonImpossibleEvolutionLevel;
             pokemonFinalEvolutionLevelSelector.Value = Configuration.PokemonEasierFinalEvolutionLevel;
             pokemonSecondEvolutionLevelSelector.Value = Configuration.PokemonEasierSecondEvolutionLevel;
+            bstRangeSelector.Value = Configuration.BSTRange;
             movePower.Value = Configuration.GoodDamagingMovePower;
             fileStreamCheck.Checked = !Configuration.UseMemoryStreams;
             browseForDirButton.Enabled = !fileStreamCheck.Checked;
@@ -76,6 +77,11 @@ namespace Randomizer
         private void bstRangeNumeric_ValueChanged(object sender, EventArgs e)
         {
             Configuration.BSTRange = (int)bstRangeSelector.Value;
+        }
+
+        private void pokemonImpossibleEvolutionLevelSelector_ValueChanged(object sender, EventArgs e)
+        {
+            Configuration.PokemonImpossibleEvolutionLevel = (int)pokemonImpossibleEvolutionLevelSelector.Value;
         }
     }
 }

--- a/Pokemon-XD-Tool/OptionsForm.resx
+++ b/Pokemon-XD-Tool/OptionsForm.resx
@@ -57,9 +57,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="infoToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>180, 17</value>
-  </metadata>
   <data name="bstRangeSelector.ToolTip" xml:space="preserve">
     <value>When using "Similar BST" checks, this is the range +/- the BST to check in.
 This is also the amount the range widens by if it doesn't find a match the first time.
@@ -71,7 +68,4 @@ e.g. 1st check for BST 300 and range of 10 = 290 - 310
 Check this only if you have very low RAM or want to extract the randomized game files.
 Use with caution on SSDs.</value>
   </data>
-  <metadata name="folderBrowserDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/Pokemon-XD-Tool/Randomizer.csproj
+++ b/Pokemon-XD-Tool/Randomizer.csproj
@@ -8,9 +8,9 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Authors>rotobash</Authors>
     <PackageProjectUrl>https://github.com/rotobash/pokemon-ngc-rando</PackageProjectUrl>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
-    <Version>1.3.0</Version>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
+    <Version>1.3.1</Version>
     <ApplicationIcon>Images\freemyboy.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/Pokemon-XD-Tool/Shufflers/PokemonTraitShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/PokemonTraitShuffler.cs
@@ -53,7 +53,7 @@ namespace Randomizer.Shufflers
                 foreach (var poke in extractedGame.ValidPokemon)
                 {
                     // prevent loops and multiple pokemon evolving into the same pokemon
-                    var pokeFilter = extractedGame.ValidPokemon.Where(p => !pokeEvosRandomized.Contains(p.Index));
+                    var pokeFilter = extractedGame.ValidPokemon.Where(p => p.Index != poke.Index && !pokeEvosRandomized.Contains(p.Index));
                     var isEevee = poke.Name.Equals("eevee", StringComparison.InvariantCultureIgnoreCase);
 
                     // check for eevee, don't bother with type filtering

--- a/Pokemon-XD-Tool/Shufflers/PokemonTraitShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/PokemonTraitShuffler.cs
@@ -65,9 +65,10 @@ namespace Randomizer.Shufflers
                     for (int i = 0; i < poke.Evolutions.Length; i++)
                     {
                         var evolution = poke.Evolutions[i];
-                        if (evolution.EvolutionMethod == EvolutionMethods.None && i > 0) continue;
+                        if (evolution.EvolutionMethod == EvolutionMethods.None && i > 0) 
+                            continue;
 
-                        if (settings.EvolutionHasSimilarStrength)
+                        if (settings.EvolutionHasSimilarStrength && pokeFilter.Any())
                         {
                             var similarStrengthPoke = evolution.EvolutionMethod != EvolutionMethods.None ? evolution.EvolvesInto : poke.Index;
                             pokeFilter = Helpers.GetSimilarBsts(similarStrengthPoke, pokeFilter, extractedGame.PokemonList);

--- a/Pokemon-XD-Tool/Shufflers/TeamShuffler.cs
+++ b/Pokemon-XD-Tool/Shufflers/TeamShuffler.cs
@@ -143,7 +143,7 @@ namespace Randomizer.Shufflers
             if (settings.ForceFullyEvolved && forceFullyEvolved)
             {
                 var currPoke = extractedGame.PokemonList[pokemon.Pokemon];
-                while (currPoke.Evolutions.Any(e => e.EvolvesInto > 0))
+                while (currPoke.Evolutions.Any(e => e.EvolutionMethod != EvolutionMethods.None))
                 {
                     if (Helpers.CheckForSplitOrEndEvolution(currPoke, out var count) && count > 0)
                     {


### PR DESCRIPTION
Fixes #51 

Also fixes:
- Options menu options not updating properly
- Bug where pokemon could randomize into itself
- Bug where "evolves into" is set but not evolution method